### PR TITLE
CLOUDP-59363: User can view/update/delete a single document

### DIFF
--- a/src/main/java/org/objectlabs/json/JsonParser.java
+++ b/src/main/java/org/objectlabs/json/JsonParser.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.bson.BSONObject;
 import org.bson.BsonTimestamp;
+import org.bson.Document;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.ObjectId;
@@ -306,6 +307,13 @@ public class JsonParser {
         if(o instanceof JSONArray) {
             return ((JSONArray)o).toList().stream().map(e -> deepMap(e, f)).collect(Collectors.toList());
         }
+        if(o instanceof Document) {
+            final DBObject obj = new BasicDBObject();
+            for(final String key : ((Document) o).keySet()) {
+                obj.put(key, deepMap(((Document) o).get(key), f));
+            }
+            return obj;
+        }
         return f.apply(o);
     }
 
@@ -362,6 +370,10 @@ public class JsonParser {
         } else {
             w.write(serialize(o));
         }
+    }
+
+    public Object jsonify(final Object o) {
+        return parse(serialize(o));
     }
 
     public static String prettyPrint(Object o, int indentFactor) {

--- a/src/main/java/org/objectlabs/mongodb/MongoUtils.java
+++ b/src/main/java/org/objectlabs/mongodb/MongoUtils.java
@@ -14,6 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.UUID;
+import org.bson.Document;
 import org.bson.types.ObjectId;
 
 public class MongoUtils {
@@ -66,7 +67,8 @@ public class MongoUtils {
 
   public static DBObject findOne(MongoCollection collection, BasicDBObject query) {
     final MongoCursor cursor = collection.find(query).limit(1).iterator();
-    return cursor.hasNext() ? (DBObject) cursor.next() : null;
+    final Document document = cursor.hasNext() ? (Document) cursor.next() : null;
+    return document == null ? null : new BasicDBObject(document);
   }
 
   public static DBObject findOneById(MongoCollection collection, Object id) {

--- a/src/main/java/org/olabs/portal/api/CollectionResource.java
+++ b/src/main/java/org/olabs/portal/api/CollectionResource.java
@@ -71,7 +71,7 @@ public class CollectionResource extends PortalRESTResource {
 
   private MongoCollection<Document> collection;
 
-  private MongoCollection<Document> getCollection() {
+  public MongoCollection<Document> getCollection() {
     return collection;
   }
 
@@ -296,16 +296,12 @@ public class CollectionResource extends PortalRESTResource {
   }
 
   public Resource resolveRelative(final Uri uri) {
-    /*
-     final String id = uri.toString();
-     final Object o = MongoUtils.findOneByStringId(getCollection(), id);
-     final Resource result = new ObjectResource(o);
-     result.setName(id);
-     result.setParent(this);
-     return result;
-    */
-
-    return null;
+    final String id = uri.toString();
+    final DBObject o = MongoUtils.findOneByStringId(getCollection(), id);
+    final Resource result = new ObjectResource(o);
+    result.setName(id);
+    result.setParent(this);
+    return result;
   }
 
   private BasicDBObject getQuery(final Map params) throws ResourceException {

--- a/src/main/java/org/olabs/portal/api/ObjectResource.java
+++ b/src/main/java/org/olabs/portal/api/ObjectResource.java
@@ -1,0 +1,112 @@
+package org.olabs.portal.api;
+
+import static com.mongodb.client.model.ReturnDocument.AFTER;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import java.util.Map;
+import javax.servlet.http.HttpServletResponse;
+import org.bson.Document;
+import org.objectlabs.http.HttpMethod;
+import org.objectlabs.mongodb.MongoUtils;
+import org.objectlabs.ws.RequestContext;
+import org.objectlabs.ws.ResourceException;
+
+public class ObjectResource extends PortalRESTResource {
+
+  private static final String[] METHODS =
+      new String[] {HttpMethod.GET.name(), HttpMethod.PUT.name(), HttpMethod.DELETE.name()};
+  private DBObject _object;
+
+  public ObjectResource(final DBObject o) {
+    super();
+    setObject(o);
+  }
+
+  public String[] getMethods() {
+    return METHODS;
+  }
+
+  public String getName() {
+    final DBObject o = getObject();
+    return o == null ? null : o.get("_id").toString();
+  }
+
+  public DBObject getObject() {
+    return _object;
+  }
+
+  public void setObject(final DBObject value) {
+    _object = value;
+  }
+
+  @Override
+  public Object handleGet(final Map parameters, final RequestContext context)
+      throws ResourceException {
+    if (getObject() == null) {
+      throw new ResourceException(HttpServletResponse.SC_NOT_FOUND, "Document not found");
+    }
+    return getObject();
+  }
+
+  @Override
+  public Object handlePut(final Object o, final RequestContext context) throws ResourceException {
+    final BasicDBObject update = (BasicDBObject) o;
+    if (MongoUtils.isCollectionReadOnly(getCollection())) {
+      throw new ResourceException(HttpServletResponse.SC_FORBIDDEN);
+    }
+    if (update != null) {
+      final CollectionResource parent = (CollectionResource) getParent();
+      final MongoCollection<Document> c = parent.getCollection();
+      try {
+        final BasicDBObject idQuery = new BasicDBObject("_id", getObject().get("_id"));
+        if (isUpdateDirective(update)) {
+          final Document updated =
+              c.findOneAndUpdate(
+                  idQuery, update, new FindOneAndUpdateOptions().returnDocument(AFTER));
+          return new BasicDBObject(updated);
+        } else {
+          final Document updated =
+              c.findOneAndReplace(
+                  idQuery,
+                  new Document(update),
+                  new FindOneAndReplaceOptions().returnDocument(AFTER));
+          return new BasicDBObject(updated);
+        }
+      } catch (final IllegalArgumentException e) {
+        throw new ResourceException(
+            HttpServletResponse.SC_BAD_REQUEST,
+            "Invalid object " + update + " - " + e.getMessage());
+      }
+    } else {
+      throw new ResourceException(HttpServletResponse.SC_BAD_REQUEST, "Update object is missing.");
+    }
+  }
+
+  @Override
+  public Object handleDelete(final RequestContext context) throws ResourceException {
+    if (MongoUtils.isCollectionReadOnly(getCollection())) {
+      throw new ResourceException(HttpServletResponse.SC_FORBIDDEN);
+    }
+    final DBObject object = getObject();
+    if (object != null) {
+      final CollectionResource parent = (CollectionResource) getParent();
+      final MongoCollection c = parent.getCollection();
+      c.deleteOne(new BasicDBObject("_id", object.get("_id")));
+    } else {
+      throw new ResourceException(HttpServletResponse.SC_NOT_FOUND, "Document not found");
+    }
+    return object;
+  }
+
+  protected MongoCollection<Document> getCollection() {
+    return ((CollectionResource) getParent()).getCollection();
+  }
+
+  private boolean isUpdateDirective(final DBObject object) {
+    return !object.keySet().isEmpty() && object.keySet().iterator().next().startsWith("$");
+  }
+}

--- a/src/test/java/org/olabs/portal/api/BaseResourceTest.java
+++ b/src/test/java/org/olabs/portal/api/BaseResourceTest.java
@@ -1,11 +1,27 @@
 package org.olabs.portal.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.objectlabs.mongodb.MongoUtils.oid;
+
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBRef;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+import org.bson.types.Binary;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.objectlabs.mongodb.MongoUtils;
 
 @RunWith(Parameterized.class)
 public abstract class BaseResourceTest {
@@ -14,6 +30,9 @@ public abstract class BaseResourceTest {
   public static final String SHARED_CLUSTER_ID = "rs-ds253357";
   public static final String TEST_CLIENT_NAME = "test";
   public static final String PROD_CLIENT_NAME = "production";
+  public static final Date TEST_DATE = new Date(1000000000);
+  public static final UUID TEST_UUID = UUID.randomUUID();
+  public static final Binary TEST_BINARY = new Binary(new byte[] {1, 2, 3, 4});
 
   private static final String TEST_CONFIG_ENV_VAR = "MLAB_DATA_API_TEST_CONFIG";
   private static final String TEST_PROD_API_KEY_ENV_VAR = "MLAB_DATA_API_TEST_PROD_KEY";
@@ -61,5 +80,55 @@ public abstract class BaseResourceTest {
 
   public boolean isProductionClient() {
     return client.getName().equals(PROD_CLIENT_NAME);
+  }
+
+  protected static Map makeTestMap(final String variable) {
+    final Map<String, Object> m = new HashMap<>();
+    m.put("date", TEST_DATE);
+    m.put("int", 100);
+    m.put("string", "string");
+    m.put("objectid", oid(1000));
+    m.put("boolean", false);
+    m.put("array", new JSONArray(List.of("a", "b", "c")));
+    m.put("object", BasicDBObjectBuilder.start().add("a", 1).add("b", 2).add("c", 3).get());
+    m.put("uuid", TEST_UUID);
+    m.put("binary", TEST_BINARY);
+    m.put("dbref", new DBRef("this", "that"));
+    m.put("timestamp", new BsonTimestamp(1000000000, 100));
+    m.put("variable", variable);
+    return m;
+  }
+
+  protected static Document makeTestDocument(final String variable) {
+    return new Document(makeTestMap(variable));
+  }
+
+  protected void assertTestDocumentValid(final JSONObject o) {
+    // date
+    assertEquals(MongoUtils.toISODateString(TEST_DATE), ((JSONObject) o.get("date")).get("$date"));
+    // int
+    assertEquals(100, o.get("int"));
+    // string
+    assertEquals("string", o.get("string"));
+    // ObjectId
+    assertTrue(((JSONObject) o.get("objectid")).has("$oid"));
+    assertEquals(oid(1000).toHexString(), ((JSONObject) o.get("objectid")).get("$oid"));
+    // boolean
+    assertEquals(false, o.get("boolean"));
+    // array
+    assertEquals(List.of("a", "b", "c"), ((JSONArray) o.get("array")).toList());
+    // object
+    assertEquals(Map.of("a", 1, "b", 2, "c", 3), ((JSONObject) o.get("object")).toMap());
+    // uuid
+    assertEquals(TEST_UUID.toString(), ((JSONObject) o.get("uuid")).get("$uuid"));
+    // binary
+    assertEquals("00", ((JSONObject) o.get("binary")).getString("$type"));
+    assertEquals("AQIDBA==", ((JSONObject) o.get("binary")).getString("$binary"));
+    // dbref
+    assertEquals("this", ((JSONObject) o.get("dbref")).get("$ref"));
+    assertEquals("that", ((JSONObject) o.get("dbref")).get("$id"));
+    // timestamp
+    assertEquals(1000000000, ((JSONObject) o.get("timestamp")).get("$ts"));
+    assertEquals(100, ((JSONObject) o.get("timestamp")).get("$inc"));
   }
 }

--- a/src/test/java/org/olabs/portal/api/CollectionResourceIntTests.java
+++ b/src/test/java/org/olabs/portal/api/CollectionResourceIntTests.java
@@ -8,25 +8,17 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import static org.objectlabs.mongodb.MongoUtils.oid;
 import static org.objectlabs.mongodb.MongoUtils.toISODateString;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
-import com.mongodb.DBRef;
 import com.mongodb.client.MongoCollection;
 import java.io.IOException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletResponse;
-import org.bson.BsonTimestamp;
-import org.bson.Document;
-import org.bson.types.Binary;
 import org.bson.types.ObjectId;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -42,9 +34,6 @@ import org.slf4j.LoggerFactory;
 public class CollectionResourceIntTests extends BaseResourceTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(CollectionResourceIntTests.class);
-  private static final Date TEST_DATE = new Date(1000000000);
-  private static final UUID TEST_UUID = UUID.randomUUID();
-  private static final Binary TEST_BINARY = new Binary(new byte[] {1, 2, 3, 4});
   private static final String TEST_DB = "test";
   private static final String TEST_GET_COLLECTION = new ObjectId().toString();
   private static final String TEST_POST_COLLECTION = new ObjectId().toString();
@@ -114,35 +103,6 @@ public class CollectionResourceIntTests extends BaseResourceTest {
             .collect(Collectors.toList())
             .containsAll(List.of("1", "2", "3")));
     all.forEach(o -> assertTestDocumentValid((JSONObject) o));
-  }
-
-  private void assertTestDocumentValid(final JSONObject o) {
-    // date
-    assertEquals(MongoUtils.toISODateString(TEST_DATE), ((JSONObject) o.get("date")).get("$date"));
-    // int
-    assertEquals(100, o.get("int"));
-    // string
-    assertEquals("string", o.get("string"));
-    // ObjectId
-    assertTrue(((JSONObject) o.get("objectid")).has("$oid"));
-    assertEquals(oid(1000).toHexString(), ((JSONObject) o.get("objectid")).get("$oid"));
-    // boolean
-    assertEquals(false, o.get("boolean"));
-    // array
-    assertEquals(List.of("a", "b", "c"), ((JSONArray) o.get("array")).toList());
-    // object
-    assertEquals(Map.of("a", 1, "b", 2, "c", 3), ((JSONObject) o.get("object")).toMap());
-    // uuid
-    assertEquals(TEST_UUID.toString(), ((JSONObject) o.get("uuid")).get("$uuid"));
-    // binary
-    assertEquals("00", ((JSONObject) o.get("binary")).getString("$type"));
-    assertEquals("AQIDBA==", ((JSONObject) o.get("binary")).getString("$binary"));
-    // dbref
-    assertEquals("this", ((JSONObject) o.get("dbref")).get("$ref"));
-    assertEquals("that", ((JSONObject) o.get("dbref")).get("$id"));
-    // timestamp
-    assertEquals(1000000000, ((JSONObject) o.get("timestamp")).get("$ts"));
-    assertEquals(100, ((JSONObject) o.get("timestamp")).get("$inc"));
   }
 
   @Test
@@ -564,26 +524,5 @@ public class CollectionResourceIntTests extends BaseResourceTest {
 
   private ApiPathBuilder getCollectionUrl(final String collection) {
     return ApiPathBuilder.start().cluster(DEDICATED_CLUSTER_ID).db(TEST_DB).collection(collection);
-  }
-
-  private static Map makeTestMap(final String variable) {
-    final Map<String, Object> m = new HashMap<>();
-    m.put("date", TEST_DATE);
-    m.put("int", 100);
-    m.put("string", "string");
-    m.put("objectid", oid(1000));
-    m.put("boolean", false);
-    m.put("array", new JSONArray(List.of("a", "b", "c")));
-    m.put("object", BasicDBObjectBuilder.start().add("a", 1).add("b", 2).add("c", 3).get());
-    m.put("uuid", TEST_UUID);
-    m.put("binary", TEST_BINARY);
-    m.put("dbref", new DBRef("this", "that"));
-    m.put("timestamp", new BsonTimestamp(1000000000, 100));
-    m.put("variable", variable);
-    return m;
-  }
-
-  private static Document makeTestDocument(final String variable) {
-    return new Document(makeTestMap(variable));
   }
 }

--- a/src/test/java/org/olabs/portal/api/MlabDataApiClient.java
+++ b/src/test/java/org/olabs/portal/api/MlabDataApiClient.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -74,6 +75,15 @@ public class MlabDataApiClient {
 
   public JSONObject putJson(final String pPath, final String pData) throws IOException {
     final String result = put(pPath, pData);
+    return result == null ? null : new JSONObject(result);
+  }
+
+  public String delete(final String pPath) throws IOException {
+    return doRequestString(new HttpDelete(getPathUrl(pPath)));
+  }
+
+  public JSONObject deleteJson(final String pPath) throws IOException {
+    final String result = delete(pPath);
     return result == null ? null : new JSONObject(result);
   }
 

--- a/src/test/java/org/olabs/portal/api/ObjectResourceIntTests.java
+++ b/src/test/java/org/olabs/portal/api/ObjectResourceIntTests.java
@@ -1,0 +1,160 @@
+package org.olabs.portal.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.MongoCollection;
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.http.HttpServletResponse;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.objectlabs.json.JsonParser;
+import org.objectlabs.mongodb.MongoUtils;
+import org.objectlabs.ws.ResourceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ObjectResourceIntTests extends BaseResourceTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CollectionResourceIntTests.class);
+  private static final String TEST_DB = "test";
+  private static final String TEST_COLLECTION = new ObjectId().toString();
+  private static final JsonParser JSON_PARSER = new JsonParser();
+
+  @AfterClass
+  public static void afterClass() {
+    getTestCollection().drop();
+  }
+
+  private static MongoCollection<Document> getTestCollection() {
+    return ApiConfig.getInstance()
+        .getClusterConnection(DEDICATED_CLUSTER_ID)
+        .getDatabase(TEST_DB)
+        .getCollection(TEST_COLLECTION);
+  }
+
+  @Test
+  public void testGet() throws IOException {
+    // test fetching documents with different types of IDs
+    final List ids =
+        List.of(
+            new ObjectId(),
+            client.getName() + "_string",
+            new ObjectId().toHexString(),
+            client.getName().hashCode(),
+            client.getName().hashCode() + 0.123d,
+            UUID.randomUUID());
+    for (final Object id : ids) {
+      testGet(id);
+    }
+  }
+
+  @Test
+  public void testGet_notFound() throws IOException {
+    try {
+      client.getJson(getObjectUrl("does_not_exist"));
+      fail("Expected request to fail");
+    } catch (final ResourceException e) {
+      assertEquals(HttpServletResponse.SC_NOT_FOUND, e.getStatusCode());
+    }
+  }
+
+  @Test
+  public void testPut_replace() throws IOException {
+    final String variable = "objectReplace";
+    final Document doc = makeTestDocument(variable);
+    getTestCollection().insertOne(doc);
+    doc.put("date", new Date(0));
+    doc.put("newField", "new");
+    final JSONObject replaced =
+        client.putJson(getObjectUrl(doc.get("_id").toString()), JSON_PARSER.serialize(doc));
+    assertNotNull(replaced);
+    assertEquals(variable, replaced.getString("variable"));
+    assertEquals(
+        MongoUtils.toISODateString(new Date(0)),
+        ((JSONObject) replaced.get("date")).getString("$date"));
+  }
+
+  @Test
+  public void testPut_update() throws IOException {
+    final String variable = "objectReplace";
+    final Document doc = makeTestDocument(variable);
+    getTestCollection().insertOne(doc);
+    final BasicDBObject update =
+        new BasicDBObject("$set", new BasicDBObject("date", new Date(0)).append("newField", "new"));
+    final JSONObject replaced =
+        client.putJson(getObjectUrl(doc.get("_id").toString()), JSON_PARSER.serialize(update));
+    assertNotNull(replaced);
+    assertEquals(variable, replaced.getString("variable"));
+    assertEquals(
+        MongoUtils.toISODateString(new Date(0)),
+        ((JSONObject) replaced.get("date")).getString("$date"));
+  }
+
+  @Test
+  public void testDelete() throws IOException {
+    // test deleting documents with different types of IDs
+    final List ids =
+        List.of(
+            new ObjectId(),
+            client.getName() + "_deleteString",
+            new ObjectId().toHexString(),
+            client.getName().hashCode() + 3,
+            client.getName().hashCode() + 0.456d,
+            UUID.randomUUID());
+    for (final Object id : ids) {
+      testDelete(id);
+    }
+  }
+
+  private void testGet(final Object id) throws IOException {
+    final Document doc = makeTestDocument("objectGet");
+    doc.put("_id", id);
+    getTestCollection().insertOne(doc);
+
+    final String idClass = doc.get("_id").getClass().getName();
+    final JSONObject obj = client.getJson(getObjectUrl(doc.get("_id").toString()));
+    assertNotNull(String.format("lookup by %s id failed", idClass), obj);
+    assertTestDocumentValid(obj);
+    assertEquals("objectGet", obj.getString("variable"));
+    assertEquals(
+        String.format("IDs of class %s don't match", idClass),
+        JSON_PARSER.jsonify(doc.get("_id")),
+        JSON_PARSER.jsonify(obj.get("_id")));
+  }
+
+  private void testDelete(final Object id) throws IOException {
+    final Document doc = makeTestDocument("objectDelete");
+    doc.put("_id", id);
+    getTestCollection().insertOne(doc);
+
+    final String idClass = doc.get("_id").getClass().getName();
+    final JSONObject obj = client.deleteJson(getObjectUrl(doc.get("_id").toString()));
+    assertNotNull(String.format("lookup by %s id failed", idClass), obj);
+    assertTestDocumentValid(obj);
+    assertEquals("objectDelete", obj.getString("variable"));
+    assertEquals(
+        String.format("IDs of class %s don't match", idClass),
+        JSON_PARSER.jsonify(doc.get("_id")),
+        JSON_PARSER.jsonify(obj.get("_id")));
+    // verify document no longer exists
+    assertEquals(0, getTestCollection().countDocuments(new BasicDBObject("_id", id)));
+  }
+
+  private String getObjectUrl(final String id) {
+    return ApiPathBuilder.start()
+        .cluster(DEDICATED_CLUSTER_ID)
+        .db(TEST_DB)
+        .collection(TEST_COLLECTION)
+        .object(id)
+        .toString();
+  }
+}


### PR DESCRIPTION
[CLOUDP-59363](https://jira.mongodb.org/browse/CLOUDP-59363)

- Implementing all CRUD behavior for the document endpoint: https://docs.mlab.com/data-api/#view-edit-delete-document

Testing

- Added integration tests to test all operations and ensure that the behavior matches the production API