### PR TITLE
CLOUDP-59365: User can list commands available for a database

### DIFF
--- a/src/main/java/org/objectlabs/json/JsonParser.java
+++ b/src/main/java/org/objectlabs/json/JsonParser.java
@@ -16,6 +16,7 @@ import java.io.Writer;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.bson.BSONObject;
@@ -305,6 +306,13 @@ public class JsonParser {
         }
         if(o instanceof JSONArray) {
             return ((JSONArray)o).toList().stream().map(e -> deepMap(e, f)).collect(Collectors.toList());
+        }
+        if(o instanceof Map) {
+            final DBObject obj = new BasicDBObject();
+            for(final Object key : ((Map) o).keySet()) {
+                obj.put((String) key, deepMap(((Map) o).get(key), f));
+            }
+            return obj;
         }
         return f.apply(o);
     }

--- a/src/main/java/org/olabs/portal/api/CommandsResource.java
+++ b/src/main/java/org/olabs/portal/api/CommandsResource.java
@@ -1,0 +1,48 @@
+package org.olabs.portal.api;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.MongoDatabase;
+import java.util.Map;
+import org.bson.Document;
+import org.objectlabs.http.HttpMethod;
+import org.objectlabs.ws.RequestContext;
+import org.objectlabs.ws.ResourceException;
+
+public class CommandsResource extends PortalRESTResource {
+
+  public CommandsResource(final MongoDatabase db) {
+    super();
+    setDatabase(db);
+  }
+
+  private static final String[] METHODS = {HttpMethod.GET.name()};
+
+  public String[] getMethods() {
+    return METHODS;
+  }
+
+  public String getName() {
+    return "commands";
+  }
+
+  private MongoDatabase database;
+
+  public MongoDatabase getDatabase() {
+    return database;
+  }
+
+  public void setDatabase(final MongoDatabase value) {
+    database = value;
+  }
+
+  @Override
+  public Object handleGet(final Map parameters, final RequestContext context)
+      throws ResourceException {
+    final MongoDatabase db = getDatabase();
+    final Document result = db.runCommand(new BasicDBObject("listCommands", 1));
+    if (result.getDouble("ok") <= 0) {
+      throw new ResourceException(result.getString("errmsg"));
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/olabs/portal/api/DatabaseResource.java
+++ b/src/main/java/org/olabs/portal/api/DatabaseResource.java
@@ -50,11 +50,11 @@ public class DatabaseResource extends PortalRESTResource {
     String head = uri.getHead();
     if (head.equals("collections")) {
       r = new DBCollectionsResource(getDatabase());
+    } else if (head.equals("commands")) {
+      r = new CommandsResource(getDatabase());
     }
 
     /*
-    } else if (head.equals("commands")) {
-      r = new CommandsResource(getDatabase());
     } else if (head.equals("runCommand")) {
       r = new RunCommandResource(getDatabase());
     } else if (head.equals("status")) {

--- a/src/test/java/org/olabs/portal/api/ApiPathBuilder.java
+++ b/src/test/java/org/olabs/portal/api/ApiPathBuilder.java
@@ -10,6 +10,7 @@ public class ApiPathBuilder {
   private boolean clusters;
   private boolean databases;
   private boolean collections;
+  private boolean commands;
   private String cluster;
   private String db;
   private String collection;
@@ -57,6 +58,11 @@ public class ApiPathBuilder {
     return this;
   }
 
+  public ApiPathBuilder commands() {
+    setCommands(true);
+    return this;
+  }
+
   public ApiPathBuilder query(final String key, final Object value) {
     query.put(key, value.toString());
     return this;
@@ -89,6 +95,8 @@ public class ApiPathBuilder {
               sb.append("/").append(getObject());
             }
           }
+        } else if(getCommands()) {
+          sb.append("/commands");
         }
       }
     }
@@ -127,6 +135,14 @@ public class ApiPathBuilder {
 
   private void setCollections(final boolean pCollections) {
     collections = pCollections;
+  }
+
+  public boolean getCommands() {
+    return commands;
+  }
+
+  public void setCommands(final boolean pCommands) {
+    commands = pCommands;
   }
 
   private String getCluster() {

--- a/src/test/java/org/olabs/portal/api/CommandsResourceIntTests.java
+++ b/src/test/java/org/olabs/portal/api/CommandsResourceIntTests.java
@@ -1,0 +1,24 @@
+package org.olabs.portal.api;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class CommandsResourceIntTests extends BaseResourceTest {
+
+  @Test
+  public void testGet() throws IOException {
+    final JSONObject result =
+        client.getJson(
+            ApiPathBuilder.start().cluster(DEDICATED_CLUSTER_ID).db("test").commands().toString());
+    assertNotNull(result);
+    assertTrue(result.has("commands"));
+    final JSONObject commands = (JSONObject) result.get("commands");
+    assertTrue(commands.has("aggregate"));
+    assertTrue(commands.has("applyOps"));
+    assertTrue(commands.has("collStats"));
+  }
+}

--- a/src/test/java/org/olabs/portal/api/DBCollectionsResourceIntTests.java
+++ b/src/test/java/org/olabs/portal/api/DBCollectionsResourceIntTests.java
@@ -32,6 +32,9 @@ public class DBCollectionsResourceIntTests extends BaseResourceTest {
     assertNotNull(collections);
     assertEquals(1, collections.length());
     assertTrue(collections.toList().contains("view1"));
+    assertFalse(collections.toList().contains("c1"));
+    assertFalse(collections.toList().contains("c2"));
+    assertFalse(collections.toList().contains("c3"));
   }
 
   @Test
@@ -40,11 +43,10 @@ public class DBCollectionsResourceIntTests extends BaseResourceTest {
         client.getJsonArray(
             String.format("clusters/%s/databases/test/collections?type=collection", DEDICATED_CLUSTER_ID));
     assertNotNull(collections);
-    assertEquals(4, collections.length());
     assertTrue(collections.toList().contains("c1"));
     assertTrue(collections.toList().contains("c2"));
     assertTrue(collections.toList().contains("c3"));
-    assertTrue(collections.toList().contains("objectlabs-system"));
+    assertFalse(collections.toList().contains("view1"));
   }
 
   @Test


### PR DESCRIPTION
[CLOUDP-59365](https://jira.mongodb.org/browse/CLOUDP-59365)

- Added commands endpoint, which just calls listCommands.  In hindsight, not sure why this is useful but it's in the production API so I'm including it anyway.

Testing

- Added test to compare new API to production API
