### PR TITLE
CLOUDP-59367: Publish Docker image to Amazon ECR

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -15,15 +15,16 @@ functions:
         args:
           - install
           - test
-  "install aws cli":
-    - command: shell.exec
+  "build docker image":
+    - command: subprocess.exec
       params:
-        working_dir: mlab-data-api
-        shell: bash
-        script: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
+        working_dir: mlab-data-api/src
+        binary: docker
+        args:
+          - build
+          - -t
+          - mlab-data-api
+          - .
 
 tasks:
 - name: test
@@ -33,18 +34,18 @@ tasks:
 - name: docker
   commands:
     - func: fetch source
-    - func: install aws cli
+    - func: build docker image
 
 buildvariants:
 - name: test
   display_name: run tests
   run_on:
-    - rhel76-small
+    - ubuntu1804
   tasks:
     - test
 - name: docker
   display_name: publish docker image
   run_on:
-    - rhel76-small
+    - ubuntu1804
   tasks:
     - docker

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -15,66 +15,35 @@ functions:
         args:
           - install
           - test
-  "build docker image":
-    - command: subprocess.exec
-      params:
-        working_dir: mlab-data-api/src
-        binary: docker
-        args:
-          - build
-          - -t
-          - mlab-data-api
-          - .
-  "login to ecr":
+  "publish docker image":
     - command: shell.exec
       params:
+        working_dir: mlab-data-api/src
         script: |
+          if [ "${branch_name}" != master ]; then
+            echo "Skipping docker image publication because branch is not master (${branch_name})"
+            exit 0
+          fi
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
           export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
           export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
           ./aws/dist/aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${AWS_ECR_DOCKER_TAG}
-  "tag docker image":
-    - command: subprocess.exec
-      params:
-        working_dir: mlab-data-api/src
-        binary: docker
-        args:
-          - tag
-          - mlab-data-api:latest
-          - ${AWS_ECR_DOCKER_TAG}:latest
-  "publish docker image":
-    - command: subprocess.exec
-      params:
-        working_dir: mlab-data-api/src
-        binary: docker
-        args:
-          - push
-          - ${AWS_ECR_DOCKER_TAG}:latest
+          docker build -t mlab-data-api .
+          docker tag mlab-data-api:latest ${AWS_ECR_DOCKER_TAG}:latest
+          docker push ${AWS_ECR_DOCKER_TAG}:latest
 
 tasks:
 - name: test
   commands:
     - func: fetch source
     - func: run tests
-- name: docker
-  commands:
-    - func: fetch source
-    - func: login to ecr
-    - func: build docker image
-    - func: tag docker image
     - func: publish docker image
 
 buildvariants:
 - name: test
-  display_name: run tests
+  display_name: test and publish
   run_on:
     - ubuntu1804
   tasks:
     - test
-- name: docker
-  display_name: publish docker image
-  run_on:
-    - ubuntu1804
-  tasks:
-    - docker

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -14,11 +14,27 @@ functions:
         args:
           - install
           - test
+  "build docker image":
+    - command: git.get_project
+      params:
+        directory: src
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: docker
+        args:
+          - build
+          - -t
+          - mlab-data-api
+          - .
 
 tasks:
 - name: test
   commands:
     - func: run tests
+- name: "build docker image"
+  commands:
+    - func: build docker image
 
 buildvariants:
 - name: main
@@ -27,3 +43,4 @@ buildvariants:
     - rhel70-small
   tasks:
     - test
+    - build docker image

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -19,10 +19,13 @@ functions:
     - command: shell.exec
       params:
         working_dir: mlab-data-api/src
+        shell: bash
         script: |
           if [ "${is_patch}" == "true" ]; then
             echo "Skipping docker image publication for patch build"
             exit 0
+          else
+            echo "This is not a patch build"
           fi
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -25,6 +25,30 @@ functions:
           - -t
           - mlab-data-api
           - .
+  "login to ecr":
+    - command: shell.exec
+      params:
+        script: |
+          export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+          export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${AWS_ECR_DOCKER_TAG}
+  "tag docker image":
+    - command: subprocess.exec
+      params:
+        working_dir: mlab-data-api/src
+        binary: docker
+        args:
+          - tag
+          - mlab-data-api:latest
+          - ${AWS_ECR_DOCKER_TAG}:latest
+  "publish docker image":
+    - command: subprocess.exec
+      params:
+        working_dir: mlab-data-api/src
+        binary: docker
+        args:
+          - push
+          - ${AWS_ECR_DOCKER_TAG}:latest
 
 tasks:
 - name: test
@@ -34,7 +58,10 @@ tasks:
 - name: docker
   commands:
     - func: fetch source
+    - func: login to ecr
     - func: build docker image
+    - func: tag docker image
+    - func: publish docker image
 
 buildvariants:
 - name: test

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -21,7 +21,7 @@ functions:
         working_dir: mlab-data-api/src
         shell: bash
         script: |
-          if [ "${is_patch}" == "true" ]; then
+          if [ "${is_patch}" = "true" ]; then
             echo "Skipping docker image publication for patch build"
             exit 0
           else

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -20,9 +20,11 @@ functions:
       params:
         working_dir: mlab-data-api/src
         script: |
-          if [ "${branch_name}" != master ]; then
+          if [ "${branch_name}" != "master" ]; then
             echo "Skipping docker image publication because branch is not master (${branch_name})"
             exit 0
+          else
+            echo "Publishing docker image for branch ${branch_name}"
           fi
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -32,7 +32,7 @@ tasks:
 - name: test
   commands:
     - func: run tests
-- name: "build docker image"
+- name: docker
   commands:
     - func: build docker image
 
@@ -43,4 +43,4 @@ buildvariants:
     - rhel70-small
   tasks:
     - test
-    - build docker image
+    - docker

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -37,10 +37,15 @@ tasks:
     - func: build docker image
 
 buildvariants:
-- name: main
-  display_name: main
+- name: test
+  display_name: run tests
   run_on:
-    - rhel70-small
+    - rhel76-small
   tasks:
     - test
+- name: docker
+  display_name: build docker image
+  run_on:
+    - rhel76-docker
+  tasks:
     - docker

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1,11 +1,12 @@
 functions:
-  "run tests":
+  "fetch source":
     - command: git.get_project
       params:
-        directory: src
+        directory: mlab-data-api/src
+  "run tests":
     - command: subprocess.exec
       params:
-        working_dir: src
+        working_dir: mlab-data-api/src
         env:
           JAVA_HOME: /opt/java/jdk11
           MLAB_DATA_API_TEST_PROD_KEY: ${MLAB_DATA_API_TEST_PROD_KEY}
@@ -14,27 +15,25 @@ functions:
         args:
           - install
           - test
-  "build docker image":
-    - command: git.get_project
+  "install aws cli":
+    - command: shell.exec
       params:
-        directory: src
-    - command: subprocess.exec
-      params:
-        working_dir: src
-        binary: docker
-        args:
-          - build
-          - -t
-          - mlab-data-api
-          - .
+        working_dir: mlab-data-api
+        shell: bash
+        script: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
 
 tasks:
 - name: test
   commands:
+    - func: fetch source
     - func: run tests
 - name: docker
   commands:
-    - func: build docker image
+    - func: fetch source
+    - func: install aws cli
 
 buildvariants:
 - name: test
@@ -44,8 +43,8 @@ buildvariants:
   tasks:
     - test
 - name: docker
-  display_name: build docker image
+  display_name: publish docker image
   run_on:
-    - rhel76-docker
+    - rhel76-small
   tasks:
     - docker

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -20,11 +20,9 @@ functions:
       params:
         working_dir: mlab-data-api/src
         script: |
-          if [ "${branch_name}" != "master" ]; then
-            echo "Skipping docker image publication because branch is not master (${branch_name})"
+          if [ "${is_patch}" == "true" ]; then
+            echo "Skipping docker image publication for patch build"
             exit 0
-          else
-            echo "Publishing docker image for branch ${branch_name}"
           fi
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -29,9 +29,11 @@ functions:
     - command: shell.exec
       params:
         script: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
           export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
           export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${AWS_ECR_DOCKER_TAG}
+          ./aws/dist/aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${AWS_ECR_DOCKER_TAG}
   "tag docker image":
     - command: subprocess.exec
       params:


### PR DESCRIPTION
[CLOUDP-59367](https://jira.mongodb.org/browse/CLOUDP-59367)

- Modified Evergreen config to build and publish docker image to Amazon ECR when it is building on the master branch
  - This is currently using my own AWS scratch credentials and publishing to a test ECR repo.  When we're ready we should figure out how to publish this to a more public/production repo.  It's all configurable in [Evergreen project variables](https://evergreen.mongodb.com/projects##mlab-data-api) so we should be able to change it without changing code.

Testing

- Earlier commits in this PR did not include the branch check so it did go through the whole process of building and publishing the docker image so we know that should work: https://evergreen.mongodb.com/task/mlab_data_api_test_test_patch_58a63d55f2e2c5e533cf7bdc6d6b45c2dde91716_5e7bbde20ae6065deb28d242_20_03_25_20_24_03
