### PR TITLE
CLOUDP-59368: User can easily deploy to Amazon ECS

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -23,18 +23,13 @@ functions:
         script: |
           if [ "${is_patch}" = "true" ]; then
             echo "Skipping docker image publication for patch build"
-            exit 0
           else
-            echo "This is not a patch build"
+            echo "Publishing docker image to ${DOCKER_REPO}"
           fi
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-          export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-          ./aws/dist/aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${AWS_ECR_DOCKER_TAG}
+          docker login --username ${DOCKER_REPO_USER} --password ${DOCKER_REPO_PASSWORD} ${DOCKER_REPO}
           docker build -t mlab-data-api .
-          docker tag mlab-data-api:latest ${AWS_ECR_DOCKER_TAG}:latest
-          docker push ${AWS_ECR_DOCKER_TAG}:latest
+          docker tag mlab-data-api:latest ${DOCKER_IMAGE}:latest
+          docker push ${DOCKER_IMAGE}:latest
 
 tasks:
 - name: test

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -23,6 +23,7 @@ functions:
         script: |
           if [ "${is_patch}" = "true" ]; then
             echo "Skipping docker image publication for patch build"
+            exit 0
           else
             echo "Publishing docker image to ${DOCKER_REPO}"
           fi

--- a/README.md
+++ b/README.md
@@ -1,66 +1,8 @@
 # mLab Data API
 
-## Build
+The **mLab Data API** is a standalone service for accessing MongoDB deployments using simple
+RESTful HTTP requests.  This can be used as a self-hosted replacement for the
+[mLab Data API service](https://docs.mlab.com/connecting/#data-api) which has been deprecated.
 
-```
-./gradlew build
-```
+* [Read the docs](https://github.com/mongodb/mlab-data-api/wiki)
 
-## Usage
-
-### Environment Variables
-
-* `MLAB_DATA_API_KEY`: API key to authenticate all requests
-* `MLAB_DATA_API_CONFIG`: Configuration string or name of file containing configuration
-
-### Configuration
-
-The `MLAB_DATA_API_CONFIG` environment variable must contain a string with the configuration
-settings or the name of a file containing said configuration.  The configuration may be
-specified in either YAML or JSON format.  Most users may find that YAML is more convenient
-when using a file and JSON is more convenient when specifying the configuration inline.
-
-Example (YAML):
-```
-port: 8080
-clusters:
-  rs-ds0000000: mongodb://user:pass@ds0000000.mlab.com:27001/admin
-  rs-ds1111111: mongodb://user:pass@ds1111111.mlab.com:27001/admin
-databases:
-  foo: mongodb://user:pass@ds2222222.mlab.com:27001/foo
-  bar: mongodb://user:pass@ds3333333.mlab.com:27001/bar
-```
-
-Example (JSON):
-```
-{
-  port: 8080,
-  clusters: {
-    "rs-ds0000000": "mongodb://user:pass@ds0000000.mlab.com:27001/admin",
-    "rs-ds1111111": "mongodb://user:pass@ds1111111.mlab.com:27001/admin"
-  },
-  databases: {
-    foo: "mongodb://user:pass@ds2222222.mlab.com:27001/foo",
-    bar: "mongodb://user:pass@ds3333333.mlab.com:27001/bar"
-  }
-}
-```
-
-### Run
-```
-./build/install/mlab-data-api/bin/mlab-data-api
-```
-
-## Docker
-
-### Build
-
-```
-docker build .
-```
-
-### Run
-
-```
-docker run -e MLAB_DATA_API_CONFIG='{port: [PORT], clusters: [...]}' -e MLAB_DATA_API_KEY=[KEY] -p [PORT]:[PORT] [IMAGE]
-```


### PR DESCRIPTION
[CLOUDP-59368](https://jira.mongodb.org/browse/CLOUDP-59368)

- Updated Evergreen config to publish docker image in quay.io instead of Amazon ECR
  - https://quay.io/repository/mongodb/mlab-data-api
- Documenting Amazon ECS setup procedure in [wiki](https://github.com/mongodb/mlab-data-api/wiki)
  - https://github.com/mongodb/mlab-data-api/wiki/Installation-Guide:-Amazon-ECS

Testing

- Confirmed that Evergreen can successfully publish to quay.io