### PR TITLE
CLOUDP-60479: User can use API with Atlas clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:jdk11 as builder
+FROM gradle:jdk14 as builder
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle distTar
 
-FROM openjdk:11-jre-slim
+FROM openjdk:14-alpine
 
 ARG VERSION=1.0
 

--- a/src/main/java/com/mlab/api/ClusterResource.java
+++ b/src/main/java/com/mlab/api/ClusterResource.java
@@ -35,11 +35,7 @@ public class ClusterResource extends PortalRESTResource {
     if (head.equals("databases")) {
       r = new MongoDBConnectionResource(getClusterConnection());
     } else if (head.equals("runCommand")) {
-      if (getAuthDb().equals("admin")) {
-        r = new RunCommandResource(getClusterConnection().getDatabase("admin"));
-      } else {
-        throw new ResourceException(HttpServletResponse.SC_NOT_FOUND);
-      }
+      r = new RunCommandResource(getClusterConnection().getDatabase("admin"));
     }
 
     if (r != null) {
@@ -48,9 +44,5 @@ public class ClusterResource extends PortalRESTResource {
     }
 
     return result;
-  }
-
-  private String getAuthDb() {
-    return getApiConfig().getClusterUri(getName()).getDatabase();
   }
 }

--- a/src/test/java/com/mlab/api/AtlasConnectionIntTests.java
+++ b/src/test/java/com/mlab/api/AtlasConnectionIntTests.java
@@ -1,0 +1,91 @@
+package com.mlab.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.mongodb.BasicDBObject;
+import java.io.IOException;
+import org.bson.types.ObjectId;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Test;
+
+public class AtlasConnectionIntTests extends BaseResourceTest {
+
+  private static final MlabDataApiClient CLIENT = ParameterizedClientTest.getTestClient();
+  private static final String TEST_DB = new ObjectId().toHexString();
+
+  @After
+  public void cleanUp() {
+    try {
+      ApiConfig.getInstance().getClusterConnection(ATLAS_CLUSTER_ID).getDatabase(TEST_DB).drop();
+    } catch (final Exception e) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testListDatabases() throws IOException {
+    final JSONArray dbs =
+        CLIENT.getJsonArray(
+            ApiPathBuilder.start().cluster(ATLAS_CLUSTER_ID).databases().toString());
+    assertNotNull(dbs);
+    assertTrue(dbs.toList().contains("test"));
+    assertTrue(dbs.toList().contains("admin"));
+    assertTrue(dbs.toList().contains("local"));
+  }
+
+  @Test
+  public void testCreateDatabase() throws IOException {
+    final JSONArray collections =
+        CLIENT.getJsonArray(
+            ApiPathBuilder.start().cluster(ATLAS_CLUSTER_ID).db(TEST_DB).collections().toString());
+    assertTrue(collections.isEmpty());
+  }
+
+  @Test
+  public void testCreateDocument() throws IOException {
+    final String collectionName = "c1";
+    final JSONArray docs =
+        CLIENT.getJsonArray(
+            ApiPathBuilder.start()
+                .cluster(ATLAS_CLUSTER_ID)
+                .db(TEST_DB)
+                .collection(collectionName)
+                .toString());
+    assertTrue(docs.isEmpty());
+    final JSONObject doc =
+        CLIENT.postJson(
+            ApiPathBuilder.start()
+                .cluster(ATLAS_CLUSTER_ID)
+                .db(TEST_DB)
+                .collection(collectionName)
+                .toString(),
+            new BasicDBObject(makeTestMap(collectionName)));
+    assertNotNull(doc);
+    assertTestDocumentValid(doc);
+    final JSONArray newDocs =
+        CLIENT.getJsonArray(
+            ApiPathBuilder.start()
+                .cluster(ATLAS_CLUSTER_ID)
+                .db(TEST_DB)
+                .collection(collectionName)
+                .toString());
+    assertFalse(newDocs.isEmpty());
+    assertEquals(1, newDocs.length());
+
+    final JSONObject created =
+        CLIENT.getJson(
+            ApiPathBuilder.start()
+                .cluster(ATLAS_CLUSTER_ID)
+                .db(TEST_DB)
+                .collection(collectionName)
+                .object(((JSONObject) doc.get("_id")).get("$oid").toString())
+                .toString());
+    assertTestDocumentValid(created);
+    assertEquals(doc.get("_id").toString(), created.get("_id").toString());
+  }
+}

--- a/src/test/java/com/mlab/api/BaseResourceTest.java
+++ b/src/test/java/com/mlab/api/BaseResourceTest.java
@@ -4,6 +4,8 @@ import static com.mlab.mongodb.MongoUtils.oid;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.mlab.json.JsonParser;
+import com.mlab.mongodb.MongoUtils;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBRef;
 import java.util.Date;
@@ -17,70 +19,22 @@ import org.bson.types.Binary;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import com.mlab.mongodb.MongoUtils;
 
-@RunWith(Parameterized.class)
-public abstract class BaseResourceTest {
+public class BaseResourceTest {
 
+  public static final JsonParser JSON_PARSER = new JsonParser();
   public static final String DEDICATED_CLUSTER_ID = "rs-ds113926";
   public static final String SHARED_CLUSTER_ID = "rs-ds253357";
-  public static final String TEST_CLIENT_NAME = "test";
-  public static final String PROD_CLIENT_NAME = "production";
+  public static final String ATLAS_CLUSTER_ID = "rs-ds113926_atlas";
   public static final String TEST_STRING = "string_with_utf8: Iñtërnâtiônàlizætiøn";
   public static final Date TEST_DATE = new Date(1000000000);
   public static final UUID TEST_UUID = UUID.randomUUID();
   public static final Binary TEST_BINARY = new Binary(new byte[] {1, 2, 3, 4});
 
-  private static final String TEST_CONFIG_ENV_VAR = "MLAB_DATA_API_TEST_CONFIG";
-  private static final String TEST_PROD_API_KEY_ENV_VAR = "MLAB_DATA_API_TEST_PROD_KEY";
-  private static final String TEST_API_KEY = "PggfZYDE6EWh2FCLsvGm42cq";
-
-  @Parameter public MlabDataApiClient client;
-
-  @Parameters(name = "{0}")
-  public static Iterable<? extends Object> data() {
-    return List.of(getTestClient(), getProductionClient());
-  }
-
   @Before
   public void setUp() throws Exception {
     System.setProperty(ApiConfig.APP_DIR_PROPERTY, "src/main/webapp");
     Main.start();
-  }
-
-  public static MlabDataApiClient getTestClient() {
-    final String config = System.getenv(TEST_CONFIG_ENV_VAR);
-    if (config == null) {
-      throw new AssertionError(
-          String.format("%s environment variable is required", TEST_CONFIG_ENV_VAR));
-    }
-    System.setProperty(ApiConfig.CONFIG_PROPERTY, config);
-    System.setProperty(ApiConfig.API_KEY_PROPERTY, TEST_API_KEY);
-    return new MlabDataApiClient(
-        TEST_CLIENT_NAME,
-        String.format("http://localhost:%s", ApiConfig.getInstance().getPort()),
-        TEST_API_KEY);
-  }
-
-  public static MlabDataApiClient getProductionClient() {
-    final String prodApiKey = System.getenv(TEST_PROD_API_KEY_ENV_VAR);
-    if (prodApiKey == null) {
-      throw new AssertionError(
-          String.format("%s environment variable is required", TEST_PROD_API_KEY_ENV_VAR));
-    }
-    return new MlabDataApiClient(PROD_CLIENT_NAME, "https://api.mlab.com", prodApiKey);
-  }
-
-  public boolean isTestClient() {
-    return client.getName().equals(TEST_CLIENT_NAME);
-  }
-
-  public boolean isProductionClient() {
-    return client.getName().equals(PROD_CLIENT_NAME);
   }
 
   protected static Map makeTestMap(final String variable) {

--- a/src/test/java/com/mlab/api/ClustersResourceIntTests.java
+++ b/src/test/java/com/mlab/api/ClustersResourceIntTests.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import org.json.JSONArray;
 import org.junit.Test;
 
-public class ClustersResourceIntTests extends BaseResourceTest {
+public class ClustersResourceIntTests extends ParameterizedClientTest {
 
   @Test
   public void testGet() throws IOException {

--- a/src/test/java/com/mlab/api/CollectionResourceIntTests.java
+++ b/src/test/java/com/mlab/api/CollectionResourceIntTests.java
@@ -31,13 +31,12 @@ import com.mlab.ws.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CollectionResourceIntTests extends BaseResourceTest {
+public class CollectionResourceIntTests extends ParameterizedClientTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(CollectionResourceIntTests.class);
   private static final String TEST_DB = "test";
   private static final String TEST_GET_COLLECTION = new ObjectId().toString();
   private static final String TEST_POST_COLLECTION = new ObjectId().toString();
-  private static final JsonParser JSON_PARSER = new JsonParser();
 
   @BeforeClass
   public static void setUpClass() {

--- a/src/test/java/com/mlab/api/CommandsResourceIntTests.java
+++ b/src/test/java/com/mlab/api/CommandsResourceIntTests.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Test;
 
-public class CommandsResourceIntTests extends BaseResourceTest {
+public class CommandsResourceIntTests extends ParameterizedClientTest {
 
   @Test
   public void testGet() throws IOException {

--- a/src/test/java/com/mlab/api/DBCollectionsResourceIntTests.java
+++ b/src/test/java/com/mlab/api/DBCollectionsResourceIntTests.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import org.json.JSONArray;
 import org.junit.Test;
 
-public class DBCollectionsResourceIntTests extends BaseResourceTest {
+public class DBCollectionsResourceIntTests extends ParameterizedClientTest {
 
   @Test
   public void testGet_test() throws IOException {

--- a/src/test/java/com/mlab/api/DBUsersResourceIntTests.java
+++ b/src/test/java/com/mlab/api/DBUsersResourceIntTests.java
@@ -15,7 +15,7 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Test;
 
-public class DBUsersResourceIntTests extends BaseResourceTest {
+public class DBUsersResourceIntTests extends ParameterizedClientTest {
 
   private static final String TEST_DB = "usersTest";
 

--- a/src/test/java/com/mlab/api/DatabaseResourceIntTests.java
+++ b/src/test/java/com/mlab/api/DatabaseResourceIntTests.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.Test;
 
-public class DatabaseResourceIntTests extends BaseResourceTest {
+public class DatabaseResourceIntTests extends ParameterizedClientTest {
 
   @Test
   public void testGet() throws IOException {

--- a/src/test/java/com/mlab/api/DatabasesResourceIntTests.java
+++ b/src/test/java/com/mlab/api/DatabasesResourceIntTests.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import org.json.JSONArray;
 import org.junit.Test;
 
-public class DatabasesResourceIntTests extends BaseResourceTest {
+public class DatabasesResourceIntTests extends ParameterizedClientTest {
   @Test
   public void testGet() throws IOException {
     final JSONArray databases = client.getJsonArray("databases");

--- a/src/test/java/com/mlab/api/MlabDataApiClient.java
+++ b/src/test/java/com/mlab/api/MlabDataApiClient.java
@@ -1,5 +1,7 @@
 package com.mlab.api;
 
+import com.mlab.json.JsonParser;
+import com.mongodb.DBObject;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
@@ -26,6 +28,7 @@ import org.slf4j.LoggerFactory;
 public class MlabDataApiClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(MlabDataApiClient.class);
+  private static final JsonParser JSON_PARSER = new JsonParser();
 
   private final String _name;
   private final String _host;
@@ -65,6 +68,11 @@ public class MlabDataApiClient {
     final HttpPost post = new HttpPost(getPathUrl(pPath));
     post.setEntity(new StringEntity(pData, ContentType.APPLICATION_JSON));
     return doRequestString(post);
+  }
+
+  public JSONObject postJson(final String pPath, final DBObject pData) throws IOException {
+    final String result = post(pPath, JSON_PARSER.serialize(pData));
+    return result == null ? null : new JSONObject(result);
   }
 
   public JSONObject postJson(final String pPath, final String pData) throws IOException {

--- a/src/test/java/com/mlab/api/MongoDBConnectionResourceIntTests.java
+++ b/src/test/java/com/mlab/api/MongoDBConnectionResourceIntTests.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import org.json.JSONArray;
 import org.junit.Test;
 
-public class MongoDBConnectionResourceIntTests extends BaseResourceTest {
+public class MongoDBConnectionResourceIntTests extends ParameterizedClientTest {
 
   private static Map<String, List<String>> TEST_CASES =
       Map.of(

--- a/src/test/java/com/mlab/api/ObjectResourceIntTests.java
+++ b/src/test/java/com/mlab/api/ObjectResourceIntTests.java
@@ -22,7 +22,7 @@ import com.mlab.ws.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ObjectResourceIntTests extends BaseResourceTest {
+public class ObjectResourceIntTests extends ParameterizedClientTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(CollectionResourceIntTests.class);
   private static final String TEST_DB = "test";

--- a/src/test/java/com/mlab/api/ParameterizedClientTest.java
+++ b/src/test/java/com/mlab/api/ParameterizedClientTest.java
@@ -1,0 +1,74 @@
+package com.mlab.api;
+
+import static com.mlab.mongodb.MongoUtils.oid;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBRef;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+import org.bson.types.Binary;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import com.mlab.mongodb.MongoUtils;
+
+@RunWith(Parameterized.class)
+public abstract class ParameterizedClientTest extends BaseResourceTest {
+
+  public static final String TEST_CLIENT_NAME = "test";
+  public static final String PROD_CLIENT_NAME = "production";
+
+  private static final String TEST_CONFIG_ENV_VAR = "MLAB_DATA_API_TEST_CONFIG";
+  private static final String TEST_PROD_API_KEY_ENV_VAR = "MLAB_DATA_API_TEST_PROD_KEY";
+  private static final String TEST_API_KEY = "PggfZYDE6EWh2FCLsvGm42cq";
+
+  @Parameter public MlabDataApiClient client;
+
+  @Parameters(name = "{0}")
+  public static Iterable<? extends Object> data() {
+    return List.of(getTestClient(), getProductionClient());
+  }
+
+  public static MlabDataApiClient getTestClient() {
+    final String config = System.getenv(TEST_CONFIG_ENV_VAR);
+    if (config == null) {
+      throw new AssertionError(
+          String.format("%s environment variable is required", TEST_CONFIG_ENV_VAR));
+    }
+    System.setProperty(ApiConfig.CONFIG_PROPERTY, config);
+    System.setProperty(ApiConfig.API_KEY_PROPERTY, TEST_API_KEY);
+    return new MlabDataApiClient(
+        TEST_CLIENT_NAME,
+        String.format("http://localhost:%s", ApiConfig.getInstance().getPort()),
+        TEST_API_KEY);
+  }
+
+  public static MlabDataApiClient getProductionClient() {
+    final String prodApiKey = System.getenv(TEST_PROD_API_KEY_ENV_VAR);
+    if (prodApiKey == null) {
+      throw new AssertionError(
+          String.format("%s environment variable is required", TEST_PROD_API_KEY_ENV_VAR));
+    }
+    return new MlabDataApiClient(PROD_CLIENT_NAME, "https://api.mlab.com", prodApiKey);
+  }
+
+  public boolean isTestClient() {
+    return client.getName().equals(TEST_CLIENT_NAME);
+  }
+
+  public boolean isProductionClient() {
+    return client.getName().equals(PROD_CLIENT_NAME);
+  }
+
+}

--- a/src/test/java/com/mlab/api/StatusServletIntTests.java
+++ b/src/test/java/com/mlab/api/StatusServletIntTests.java
@@ -9,7 +9,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.Test;
 
-public class StatusServletIntTests extends BaseResourceTest {
+public class StatusServletIntTests extends ParameterizedClientTest {
 
   @Test
   public void testStatus() throws IOException {


### PR DESCRIPTION
[CLOUDP-60479](https://jira.mongodb.org/browse/CLOUDP-60479)

- Modifying the way the API determines whether a connection has access to multiple databases.  Instead of basing it on the authentication database in the URI, just attempt to access the database (or call listDatabases) and if that fails with a permission error, then assume only the auth database can be accessed.  Using exceptions for flow control isn't ideal but MongoDB doesn't really offer a way to list just the dbs the user has access to (prior to 4.2).
- Unrelated: Updating the Docker base images to something more modern.  Quay.io is complaining about a security issue with the version of glibc it's seeing in the image and I'm hoping this might help.

Testing

- Adding an SRV connection to an Atlas cluster (in Evergreen config) and some tests to make sure the API works against it.
- Updating `RunCommandResourceIntTests` so that it tests the Atlas connection as well.