### PR TITLE
CLOUDP-67669: mLab Data API should allow non-encoded URL query parameters

### DIFF
--- a/src/main/java/com/mlab/api/Main.java
+++ b/src/main/java/com/mlab/api/Main.java
@@ -56,6 +56,7 @@ public class Main {
       System.out.println(String.format("Error getting config: %s", e.getMessage()));
       System.exit(1);
     }
+    _tomcat.getConnector().setAttribute("relaxedQueryChars", "\"<>[]{}");
     final String webAppDir = System.getProperty(ApiConfig.APP_DIR_PROPERTY);
     final StandardContext ctx =
         (StandardContext) _tomcat.addWebapp(WEB_APP_PATH, new File(webAppDir).getAbsolutePath());


### PR DESCRIPTION
[CLOUDP-67669](https://jira.mongodb.org/browse/CLOUDP-67669)

- Configuring embedded tomcat to allow additional non-encoded characters in query parameter values