### PR TITLE
CLOUDP-70339: mLab Data API: count should ignore skip/limit

### DIFF
--- a/src/main/java/com/mlab/api/CollectionResource.java
+++ b/src/main/java/com/mlab/api/CollectionResource.java
@@ -2,13 +2,19 @@ package com.mlab.api;
 
 import static com.mongodb.client.model.Filters.eq;
 
+import com.mlab.http.HttpMethod;
+import com.mlab.mongodb.MongoUtils;
+import com.mlab.mongodb.SecurityUtils;
+import com.mlab.ns.Uri;
+import com.mlab.ws.RequestContext;
+import com.mlab.ws.Resource;
+import com.mlab.ws.ResourceException;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.DuplicateKeyException;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcernException;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.CountOptions;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
@@ -23,13 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.bson.BSONObject;
 import org.bson.Document;
 import org.bson.types.ObjectId;
-import com.mlab.http.HttpMethod;
-import com.mlab.mongodb.MongoUtils;
-import com.mlab.mongodb.SecurityUtils;
-import com.mlab.ns.Uri;
-import com.mlab.ws.RequestContext;
-import com.mlab.ws.Resource;
-import com.mlab.ws.ResourceException;
 
 public class CollectionResource extends PortalRESTResource {
 
@@ -434,7 +433,7 @@ public class CollectionResource extends PortalRESTResource {
         }
         return result.isEmpty() ? null : result.iterator().next();
       } else if (count) {
-        return collection.countDocuments(query, new CountOptions().skip(skip).limit(limit));
+        return collection.countDocuments(query);
       } else {
         return collection
             .find(query)

--- a/src/test/java/com/mlab/api/CollectionResourceIntTests.java
+++ b/src/test/java/com/mlab/api/CollectionResourceIntTests.java
@@ -1,5 +1,6 @@
 package com.mlab.api;
 
+import static com.mlab.mongodb.MongoUtils.toISODateString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -8,8 +9,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import static com.mlab.mongodb.MongoUtils.toISODateString;
 
+import com.mlab.mongodb.MongoUtils;
+import com.mlab.ws.ResourceException;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.client.MongoCollection;
@@ -25,9 +27,6 @@ import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import com.mlab.json.JsonParser;
-import com.mlab.mongodb.MongoUtils;
-import com.mlab.ws.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,6 +182,14 @@ public class CollectionResourceIntTests extends ParameterizedClientTest {
                 .query("q", new BasicDBObject("variable", "1").toJson())
                 .toString());
     assertEquals("1", filteredCount);
+    final String countIgnoresSkipLimit =
+        client.get(
+            getCollectionUrl(TEST_GET_COLLECTION)
+                .query("c", "true")
+                .query("l", 2)
+                .query("sk", 1)
+                .toString());
+    assertEquals("3", countIgnoresSkipLimit);
   }
 
   @Test


### PR DESCRIPTION
[CLOUDP-70339](https://jira.mongodb.org/browse/CLOUDP-70339)

- The original data API ignores skip/limit when doing a count query so the new one should do the same.  This wasn't obvious because the version of the Java driver that the production API is using always ignores skip/limit, while the new Java driver that the standalone API uses can take them into account if desired.

Testing

- Added integration test case to verify that count ignores skip/limit